### PR TITLE
Nicer 'git commit' template

### DIFF
--- a/git_hooks/prepare-commit-msg
+++ b/git_hooks/prepare-commit-msg
@@ -2,4 +2,6 @@
 
 if [ "$2"  == "" -o "$2" == "merge" ]; then
     cat ../.commit_template.txt > $1
+    echo >> $1
+    git status | grep '^#' >> $1
 fi


### PR DESCRIPTION
I added the output of git status to the end of the commit message template, because it's nice to see which files are staged when writing commit messages.
